### PR TITLE
tooling(github): add node ci on push to separate badge status from PRs

### DIFF
--- a/.github/workflows/node-ci-on-or.yml
+++ b/.github/workflows/node-ci-on-or.yml
@@ -1,8 +1,8 @@
 # This workflow will do a clean install of node dependencies and run eslint and jest on the code.
-name: Node CI
+name: Pull Request
 
 on:
-  push:
+  pull_request:
     branches: [master]
 
 jobs:


### PR DESCRIPTION
The **Node CI** badge gets red when a PR fails on tests and linting. However this should not affect the current state of the repository.